### PR TITLE
Adding data frame support to gather_species()

### DIFF
--- a/R/species.R
+++ b/R/species.R
@@ -14,6 +14,7 @@
 #' @param data_code Character. The field name with the species codes in the data.
 #' @param species_list Dataframe. Species list output from \code{}
 #' @param generic_species_file Character. The full file path (including file extension)to the file containing the species list.
+#' @param by_state Logical. If \code{TRUE} then the join will attempt to use the variable \code{"SpeciesState"} if it exists. Defaults to \code{TRUE}.
 
 
 #' @export gather_species
@@ -250,17 +251,23 @@ species_join <- function(data, # field data,
                          growth_habit_file = "", # path to .csv or gdb holding tblSpeciesGrowthHabit
                          growth_habit_code = "Code",
                          overwrite_generic_species = FALSE,
-                         generic_species_file = "") {
+                         generic_species_file = "",
+                         by_state = TRUE) {
 
   # Print
   print("Gathering species data")
 
   # Set join levels, so that we can flexibly include SpeciesState
-  if ("SpeciesState" %in% names(data)) {
-    join_by <- c(data_code, "SpeciesState")
+  if (by_state) {
+    if ("SpeciesState" %in% names(data)) {
+      join_by <- c(data_code, "SpeciesState")
+    } else {
+      join_by <- data_code
+    }
   } else {
     join_by <- data_code
   }
+
 
   # Some projects use "None" to indicate "No species". Convert those to N instead
   data <- data %>% dplyr::mutate_at(

--- a/R/species.R
+++ b/R/species.R
@@ -304,13 +304,24 @@ species_join <- function(data, # field data,
       species_list$UpdatedSpeciesCode <- as.character(species_list$UpdatedSpeciesCode)
 
       # Merge the Updated Species codes to the data
-      data_update <- dplyr::left_join(data,
-                                      dplyr::select(
-                                        species_list, data_code,
-                                        UpdatedSpeciesCode, SpeciesState
-                                      ),
-                                      by = join_by
-      )
+      if (by_state) {
+        data_update <- dplyr::left_join(data,
+                                        dplyr::select(
+                                          species_list, data_code,
+                                          UpdatedSpeciesCode, SpeciesState
+                                        ),
+                                        by = join_by
+        )
+      } else {
+        data_update <- dplyr::left_join(data,
+                                        dplyr::select(
+                                          species_list, data_code,
+                                          UpdatedSpeciesCode
+                                        ),
+                                        by = join_by
+        )
+      }
+
 
       # Overwrite the original data code with any updated species codes
       data_update <- data_update %>%

--- a/R/species.R
+++ b/R/species.R
@@ -27,12 +27,13 @@ gather_species <- function(species_file, #
 ) {
 
 
-  # check to see if the species file exists and read in the appropriate file type
-  if (!file.exists(species_file)) {
-    stop("The species file does not exist")
-  }
 
   if (is.character(species_file)) {
+    # check to see if the species file exists and read in the appropriate file type
+    if (!file.exists(species_file)) {
+      stop("The species file does not exist")
+    }
+
     # read from .csv or .gdb. If gdb we assume it is of the schema aim.gdb
     species <- switch(toupper(stringr::str_extract(species_file,
                                                    pattern = "[A-z]{3}$"

--- a/R/species.R
+++ b/R/species.R
@@ -14,7 +14,7 @@
 #' @param data_code Character. The field name with the species codes in the data.
 #' @param species_list Dataframe. Species list output from \code{}
 #' @param generic_species_file Character. The full file path (including file extension)to the file containing the species list.
-#' @param by_state Logical. If \code{TRUE} then the join will attempt to use the variable \code{"SpeciesState"} if it exists. Defaults to \code{TRUE}.
+#' @param by_species_key Logical. If \code{TRUE} then the join will attempt to use the variable \code{"SpeciesState"} if it exists. Defaults to \code{TRUE}.
 
 
 #' @export gather_species
@@ -261,13 +261,13 @@ species_join <- function(data, # field data,
                          growth_habit_code = "Code",
                          overwrite_generic_species = FALSE,
                          generic_species_file = "",
-                         by_state = TRUE) {
+                         by_species_key = TRUE) {
 
   # Print
   print("Gathering species data")
 
   # Set join levels, so that we can flexibly include SpeciesState
-  if (by_state) {
+  if (by_species_key) {
     if ("SpeciesState" %in% names(data)) {
       join_by <- c(data_code, "SpeciesState")
     } else {
@@ -313,7 +313,7 @@ species_join <- function(data, # field data,
       species_list$UpdatedSpeciesCode <- as.character(species_list$UpdatedSpeciesCode)
 
       # Merge the Updated Species codes to the data
-      if (by_state) {
+      if (by_species_key) {
         data_update <- dplyr::left_join(data,
                                         dplyr::select(
                                           species_list, data_code,

--- a/R/species.R
+++ b/R/species.R
@@ -192,14 +192,22 @@ generic_growth_habits <- function(data,
 
 
   # Connect unknown codes to SpeciesState
-  if ("SpeciesState" %in% colnames(species_list)) {
+  if ("SpeciesState" %in% colnames(species_list) & "SpeciesState" %in% data) {
     generic.code.df <- generic.code.df %>%
       subset(!is.na(species_code)) %>%
       dplyr::inner_join(., dplyr::select(
         data, !!!dplyr::vars(data_code),
         "SpeciesState"
       ))
+  } else {
+    generic.code.df <- generic.code.df %>%
+      subset(!is.na(species_code)) %>%
+      dplyr::inner_join(., dplyr::select(
+        data, !!!dplyr::vars(data_code)
+      ))
   }
+
+
   # if there are records in generic.code.df
   if (nrow(generic.code.df) > 0) {
     # Indicate that generic codes are non-noxious

--- a/R/species.R
+++ b/R/species.R
@@ -200,6 +200,7 @@ generic_growth_habits <- function(data,
         "SpeciesState"
       ))
   } else {
+    warning("Variable 'SpeciesState' is not present in either the data or the lookup table")
     generic.code.df <- generic.code.df %>%
       subset(!is.na(species_code)) %>%
       dplyr::inner_join(., dplyr::select(

--- a/R/species.R
+++ b/R/species.R
@@ -5,7 +5,7 @@
 #' @param species_growth_habit_code Character. The field name for the growth habit
 #'  codes in the species file. Defaults to \code{"GrowthHabitSub"}
 #' @param growth_habit_file Character string. The full file path (including file extension)
-#' to the file containing the growth habit list. If NULL we assume the species list contains those values
+#' to the file containing the growth habit list. If \code{""} we assume the species list contains those values. Defaults to \code{""}.
 #' @param growth_habit_code Character. The field name for the growth habit codes
 #' in the growth habit file. Defaults to \code{"Code"}
 #' @param species_code Character. The field name for the species codes in the species file.

--- a/man/AERO.Rd
+++ b/man/AERO.Rd
@@ -4,14 +4,7 @@
 \alias{aero}
 \title{Calculate AERO Inputs}
 \usage{
-aero(
-  lpi_tall,
-  gap_tall,
-  height_tall,
-  header,
-  texture_file,
-  folder_location = "~/Projects/LandscapeDataCommons/AERO/"
-)
+aero(lpi_tall, gap_tall, height_tall, header, texture_file, folder_location)
 }
 \arguments{
 \item{lpi_tall}{Table. Line-point intercept data in tall format}

--- a/man/species.Rd
+++ b/man/species.Rd
@@ -34,7 +34,8 @@ species_join(
   growth_habit_file = "",
   growth_habit_code = "Code",
   overwrite_generic_species = FALSE,
-  generic_species_file = ""
+  generic_species_file = "",
+  by_state = TRUE
 )
 
 species_list_check(dsn_tall, species_list_file, ...)
@@ -65,6 +66,8 @@ in the growth habit file. Defaults to \code{"Code"}}
 \item{species_duration}{Character. the field name for the Duration field in the species file.}
 
 \item{generic_species_file}{Character. The full file path (including file extension)to the file containing the species list.}
+
+\item{by_state}{Logical. If \code{TRUE} then the join will attempt to use the variable \code{"SpeciesState"} if it exists. Defaults to \code{TRUE}.}
 
 \item{dsn_tall}{The observed data data source}
 

--- a/man/species.Rd
+++ b/man/species.Rd
@@ -43,7 +43,7 @@ species_list_compare(species_file, folder)
 }
 \arguments{
 \item{species_file}{Character string. The full file path (including file extension)
-to the file containing the species list.}
+to the file containing the species list OR the species list as a data frame.}
 
 \item{species_growth_habit_code}{Character. The field name for the growth habit
 codes in the species file. Defaults to \code{"GrowthHabitSub"}}

--- a/man/species.Rd
+++ b/man/species.Rd
@@ -27,7 +27,7 @@ generic_growth_habits(
 species_join(
   data,
   data_code = "code",
-  species_file = "",
+  species_file,
   species_code = "SpeciesCode",
   species_growth_habit_code = "GrowthHabitSub",
   species_duration = "Duration",

--- a/man/species.Rd
+++ b/man/species.Rd
@@ -49,7 +49,7 @@ to the file containing the species list OR the species list as a data frame.}
 codes in the species file. Defaults to \code{"GrowthHabitSub"}}
 
 \item{growth_habit_file}{Character string. The full file path (including file extension)
-to the file containing the growth habit list. If NULL we assume the species list contains those values}
+to the file containing the growth habit list. If \code{""} we assume the species list contains those values. Defaults to \code{""}.}
 
 \item{growth_habit_code}{Character. The field name for the growth habit codes
 in the growth habit file. Defaults to \code{"Code"}}


### PR DESCRIPTION
This is a quick patch that:

- Adds support for data frames as the value provided for the argument species_file for situations where the species list has already been read into the working environment (e.g., a species list has been read in and manipulated, making the original file out of date)
  - Removes the string requirement from the argument species_file in gather_species() and species_join()
  - Updates documentation to reflect the change in the species_file argument
- Updates documentation that indicated that NULL was a valid value for the argument growth_habit_file to correctly indicate an empty character string instead