### PR TITLE
Dynamic LMF LineLengthAmount calculations

### DIFF
--- a/R/gather_gap.R
+++ b/R/gather_gap.R
@@ -358,7 +358,7 @@ gather_gap_lmf <- function(dsn = NULL,
                                         "END_GAP", "PrimaryKey", "DBKey")) %>%
     dplyr::select(-zero)
 
-  # convert to metric, original data are in decimal feet
+  # convert to metric (cm), original data are in decimal feet
   gintercept$START_GAP <- gintercept$START_GAP * 30.48
   gintercept$END_GAP <- gintercept$END_GAP * 30.48
   gintercept$Gap <- abs(gintercept$END_GAP - gintercept$START_GAP)


### PR DESCRIPTION
Changes to gather_gap_lmf()

- Now supports reading in ESFSG table (mandatory)
- Uses information in ESFSG to dynamically calculate line lengths instead of assuming default transect length. That is, only transect segments with ESFSG_STATE values indicating sampling are considered for transect length calculation. ESFSG_STATE values excluded from the calculations are "XI", "XR", "XN", and "XW" based on the LMF Handbook 2022 section 8.6.2.