### PR TITLE
Ldc ingests

### DIFF
--- a/R/aim_gdb.R
+++ b/R/aim_gdb.R
@@ -1187,10 +1187,13 @@ height_calc <- function(header,
     # All other height calculations based on the other variables include records
     # without considering this.
     dplyr::mutate(.data = _,
-                  include = (is.na(Species) & !is.na(Height)) |
-                    GrowthHabit_measured == GrowthHabit,
-                  # include = TRUE
+           Species = dplyr::replace_values(x = Species,
+                                           to = NA,
+                                           from = c("")),
+           include = (!is.na(Height) & is.na(Species)) |
+             (GrowthHabit_measured == GrowthHabit)
     )
+
 
 
   # if (omit_garbage) {

--- a/R/aim_gdb.R
+++ b/R/aim_gdb.R
@@ -500,15 +500,14 @@ build_indicators <- function(header, source,
                              "FormType",
                              "ViewOBJECTID",
                              "Shape")
-      feature_class_field_names <- sf::st_read(dsn = dsn,
-                                               layer = source_layer) |>
+      feature_class_field_names <- sf::st_read(dsn = dsn, layer = source_layer) |>
         names() |>
-        setdiff(x = _,
-                internal_gdb_vars)
+        setdiff(y = internal_gdb_vars) # R automatically pushes the names into 'x'
 
-      expected_indicator_variables <- feature_class_field_names[stringr::str_detect(string = feature_class_field_names,
-                                                                                    pattern = "(Cover)|(^[FA]H)|(SoilStability)|(^Hgt)|(^Num)|(^SagebrushShape)")]
-      #
+      expected_indicator_variables <- feature_class_field_names[stringr::str_detect(
+        string = feature_class_field_names,
+        pattern = "(Cover)|(^[FA]H)|(SoilStability)|(^Hgt)|(^Num)|(^SagebrushShape)"
+      )]   #
       indicator_field_names <- data.frame(
         name = names(all_indicators),
         calculated = "yes"
@@ -602,10 +601,6 @@ lpi_calc <- function(header,
   }
 
   #### Grouping variables lists ------------------------------------------------
-  # These are the groupings of variables we'll use to calculate the indicators,
-  # organized by which hit (first, any, or basal).
-  # Note that a number of these variables will be defined below under:
-  # Joining species info > Sanitization/harmonization
   if (!is.null(indicators_vars)) {
     if (!is.list(indicators_vars)) {
       stop("When provided, indicators_vars must be a named list using one or more of the names 'any', 'first', and 'basal'")
@@ -615,8 +610,7 @@ lpi_calc <- function(header,
                                 y = c("any", "first", "basal"))
     if (length(extraneous_names) > 0 & verbose) {
       message(paste0("The following names in indicators_vars are not recognized and any variable groupings they concatin will not be used in calculations: ",
-                     paste(extraneous_names,
-                           collapse = ", ")))
+                     paste(extraneous_names, collapse = ", ")))
     }
 
     indicators_vars <- indicators_vars[intersect(x = names(indicators_vars),
@@ -626,15 +620,13 @@ lpi_calc <- function(header,
       stop("When provided, indicators_vars must be a named list using one or more of the names 'any', 'first', and 'basal'")
     }
 
-    indicators_vars_lists <- sapply(X = indicators_vars,
-                                    FUN = is.list)
+    indicators_vars_lists <- sapply(X = indicators_vars, FUN = is.list)
     if (!all(indicators_vars_lists)) {
       stop("When provided, indicators_vars must be a named list of lists of variable names. One or more of the objects in indicators_vars is not a list.")
     }
 
     indicators_vars_character <- unlist(indicators_vars) |>
-      sapply(X = _,
-             FUN = is.list)
+      sapply(FUN = is.character) # Switched to is.character to accurately validate strings
     if (!all(indicators_vars_character)) {
       stop("When provided, indicators_vars must be a named list of lists of variable names. One or more of the objects in a list in indicators_vars is not a character string or vector of character strings.")
     }
@@ -642,8 +634,7 @@ lpi_calc <- function(header,
     variable_groups <- indicators_vars
   } else if (verbose) {
     message("No indicators_vars list provided. The default indicator variable groupings for TerrADat will be used.")
-    variable_groups <- default_indicators_vars(source = "terradat",
-                                               verbose = verbose)
+    variable_groups <- default_indicators_vars(source = "terradat", verbose = verbose)
   }
 
   #### Handling header and raw data ############################################
@@ -662,8 +653,6 @@ lpi_calc <- function(header,
                             accept_failure = FALSE,
                             verbose = verbose)
 
-
-
   lpi_tall_header <- dplyr::left_join(x = dplyr::select(.data = header,
                                                         tidyselect::any_of(c("PrimaryKey",
                                                                              "SpeciesState",
@@ -673,46 +662,39 @@ lpi_calc <- function(header,
                                       relationship = "one-to-many",
                                       by = "PrimaryKey")
 
-    if (verbose) {
-      message("Checking species_file and reading in as necessary.")
-    }
+  if (verbose) {
+    message("Checking species_file and reading in as necessary.")
+  }
 
-    if (is.character(species_file)) {
-      current_species_file_extension <- tools::file_ext(species_file)
+  if (is.character(species_file)) {
+    current_species_file_extension <- tools::file_ext(species_file)
 
-      if (nchar(current_species_file_extension) == 0) {
-        stop("When species_file is a character string, it must be a filepath to either a CSV or a GDB (geodatabase).")
-      } else if (current_species_file_extension %in% c("CSV", "csv")) {
-        if (!file.exists(species_file)) {
-          stop(paste0("The provided species_file value, ", species_file, ", points to a file that does not exist."))
-        }
-        species_list <- read.csv(file = species_file,
-                                 stringsAsFactors = FALSE)
-      } else if (current_species_file_extension %in% c("GDB", "gdb")) {
-        species_list <- species_read_aim(dsn = species_file,
-                                         verbose = verbose)
+    if (nchar(current_species_file_extension) == 0) {
+      stop("When species_file is a character string, it must be a filepath to either a CSV or a GDB (geodatabase).")
+    } else if (current_species_file_extension %in% c("CSV", "csv")) {
+      if (!file.exists(species_file)) {
+        stop(paste0("The provided species_file value, ", species_file, ", points to a file that does not exist."))
       }
-    } else if (is.data.frame(species_file)) {
-      species_list <- species_file
-    } else {
-      stop("species_file must either be a filepath to a CSV or a GDB file or a data frame.")
+      species_list <- read.csv(file = species_file, stringsAsFactors = FALSE)
+    } else if (current_species_file_extension %in% c("GDB", "gdb")) {
+      species_list <- species_read_aim(dsn = species_file, verbose = verbose)
     }
+  } else if (is.data.frame(species_file)) {
+    species_list <- species_file
+  } else {
+    stop("species_file must either be a filepath to a CSV or a GDB file or a data frame.")
+  }
 
-    if (verbose) {
-      message("Attempting to join the species list to the LPI data.")
-    }
+  if (verbose) {
+    message("Attempting to join the species list to the LPI data.")
+  }
 
   lpi_species <- species_join(data = sf::st_drop_geometry(lpi_tall_header),
                               data_code = "code",
                               species_file = species_list,
-                              # This isn't hardcoded to accommodate other, non-
-                              # AIM species lists.
                               species_code = species_code_var,
                               species_growth_habit_code = "GrowthHabitSub",
                               species_duration = "Duration",
-                              # These won't all be present in every list, but
-                              # that shouldn't be a problem because they're only
-                              # used with an any_of().
                               species_property_vars = c("GrowthHabit",
                                                         "GrowthHabitSub",
                                                         "Duration",
@@ -728,9 +710,6 @@ lpi_calc <- function(header,
                                                         "CurrentPLANTSCode"),
                               growth_habit_file = "",
                               growth_habit_code = "Code",
-                              # This FALSE should prevent us from having to
-                              # worry about generic_species_file because that's
-                              # only used to overwrite generic species info.
                               overwrite_generic_species = FALSE,
                               generic_species_file = generic_species_file,
                               update_species_codes = FALSE,
@@ -738,29 +717,19 @@ lpi_calc <- function(header,
                               check_species = FALSE,
                               verbose = verbose)
 
-
   ##### Sanitization/harmonization #############################################
-  # One big mutate() to do all this lifting.
-  # We're harmonizing multiple variants (e.g., non-woody, nonwoody, etc. all
-  # being changed to NonWoody) and adding some additional variables that we can
-  # use for indicator calcs
   if (apply_species_adjustment) {
     lpi_species <- adjust_species_attributes(data = lpi_species,
                                              fail_on_missing = FALSE,
                                              verbose = verbose)
   }
 
-
   #### Calculations ############################################################
   ##### Total foliar cover #####################################################
   if (verbose) {
     message("Calculating total foliar cover.")
   }
-  # Rather than using pct_total_foliar_cover() which currently calculates first
-  # hit cover for each plant species and sums them (in context it can be more
-  # efficient when calculating multiple cover types) for the sake of avoiding
-  # possible rounding weirdness and also just efficiency we can use the Plant
-  # variable added in the mutate() above.
+
   total_foliar <- pct_cover(lpi_tall = lpi_species,
                             tall = TRUE,
                             hit = "any",
@@ -770,38 +739,23 @@ lpi_calc <- function(header,
     dplyr::mutate(indicator = "TotalFoliarCover")
 
   ##### All other cover ########################################################
-  # This is going to look gnarly, but automates stuff so we don't have to do the
-  # capitalization corrections by hand
-  # unique_grouping_vars <- unique(c(unlist(fh_variable_groupings),
-  #                                  unlist(ah_variable_groupings),
-  #                                  unlist(basal_variable_groupings)))
-  unique_grouping_vars <- unlist(x = variable_groups) |>
-    unique()
+  unique_grouping_vars <- unlist(x = variable_groups) |> unique()
 
   capitalization_lookup_list <- lapply(X = unique_grouping_vars,
                                        data = lpi_species,
                                        FUN = function(X, data){
-                                         # message(paste(X,
-                                         #               collapse = ", "))
                                          current_values <- unique(data[[X]])
                                          current_values <- current_values[!is.na(current_values)]
                                          if (length(current_values) > 0) {
                                            setNames(object = current_values,
-                                                    nm = paste0("^",
-                                                                toupper(current_values),
-                                                                "$"))
+                                                    nm = paste0("^", toupper(current_values), "$"))
                                          } else {
                                            NULL
                                          }
                                        })
   names(capitalization_lookup_list) <- unique_grouping_vars
 
-  # This calculates the indicators.
-  # The first level is iterating over the list variable_groups, working through
-  # the hit types and the second level is working through all the groupings
-  # within the hit type.
   cover_indicators_list <- lapply(X = names(variable_groups),
-                                  # X = "first",
                                   variable_groups = variable_groups,
                                   data = lpi_species,
                                   capitalization_lookup_list = capitalization_lookup_list,
@@ -811,9 +765,6 @@ lpi_calc <- function(header,
                                     message(paste("Calculating", current_hit, "hit indicators."))
 
                                     current_variable_groupings <- variable_groups[[current_hit]]
-                                    # For the current hit type ("first", "any",
-                                    # "basal"), calculate indicators for each
-                                    # required variable grouping
                                     current_results_list <- lapply(X = seq(length(current_variable_groupings)),
                                                                    data = data,
                                                                    hit = current_hit,
@@ -824,8 +775,7 @@ lpi_calc <- function(header,
                                                                      current_grouping_vars <- current_variable_groupings[[X]]
                                                                      if (verbose) {
                                                                        message(paste("Calculating", hit, "hit indicators grouped by the variable(s):",
-                                                                                     paste(current_grouping_vars,
-                                                                                           collapse = ", "),
+                                                                                     paste(current_grouping_vars, collapse = ", "),
                                                                                      paste0("(Grouping ", X, " of ", length(current_variable_groupings), ")")))
                                                                      }
 
@@ -837,213 +787,106 @@ lpi_calc <- function(header,
                                                                                                       verbose = verbose,
                                                                                                       digits = digits)
 
-                                                                     # Sometimes there are no data that had non-NA
-                                                                     # values in the variables of interest, so
-                                                                     # we have to be prepared for that.
                                                                      if (is.null(current_results_raw)) {
-                                                                       if (verbose) {
-                                                                         message("Adjusting indicator names.")
-                                                                       }
+                                                                       if (verbose) { message("Adjusting indicator names.") }
                                                                        return(NULL)
                                                                      }
 
-                                                                     if (verbose) {
-                                                                       message("Adjusting indicator names.")
-                                                                     }
+                                                                     if (verbose) { message("Adjusting indicator names.") }
 
-                                                                     # Now we rename the indicators.
-                                                                     # We'll split them into their component parts
-                                                                     # and then use the appropriate lookup vector
-                                                                     # for each part to correct the capitalization.
-                                                                     # There are more efficient ways to do this,
-                                                                     # but this is extensible, standardized, and
-                                                                     # basically hands-off for us when we update
-                                                                     # indicators.
                                                                      current_results <- tidyr::separate_wider_delim(data = current_results_raw,
                                                                                                                     cols = indicator,
-                                                                                                                    # Of course this doesn't use
-                                                                                                                    # actual regex despite that
-                                                                                                                    # being the tidyverse standard
                                                                                                                     delim = ".",
                                                                                                                     names = current_grouping_vars)
 
-
-                                                                     # A for loop might actually be fastest (and
-                                                                     # is certainly easiest), so that's the
-                                                                     # solution for now.
-                                                                     # I attempted to use mutate() with {{}} and
-                                                                     # := but it wasn't evaluating the
-                                                                     # str_replace_all() correctly because I couldn't
-                                                                     # convince it to retrieve the relevant vector
-                                                                     # with {{}} or dplyr::vars() for use as the
-                                                                     # string argument.
                                                                      for (current_variable in current_grouping_vars) {
                                                                        current_results[[current_variable]] <- stringr::str_replace_all(string = current_results[[current_variable]],
                                                                                                                                        pattern = capitalization_lookup_list[[current_variable]])
                                                                      }
 
-                                                                     # Having now made the variables with the
-                                                                     # corrected components, we can recombine them
                                                                      current_results <- tidyr::unite(data = current_results,
                                                                                                      col = indicator,
                                                                                                      dplyr::all_of(current_grouping_vars),
                                                                                                      sep = "")
 
-                                                                     # And add the hit prefix and "Cover" to the
-                                                                     # indicator names
                                                                      current_prefix <- switch(EXPR = hit,
                                                                                               "first" = "FH_",
                                                                                               "any" = "AH_",
                                                                                               "basal" = "AH_Basal")
                                                                      current_results <- dplyr::mutate(.data = current_results,
-                                                                                                      indicator = paste0(current_prefix,
-                                                                                                                         indicator,
-                                                                                                                         "Cover")) |>
-                                                                       # And correct for the special case indicators
-                                                                       dplyr::mutate(.data = _,
-                                                                                     indicator = stringr::str_replace_all(string = indicator,
-                                                                                                                          pattern = nonstandard_indicator_lookup))
-                                                                     # We'll keep only the bare minimum here.
-                                                                     dplyr::select(.data = current_results,
-                                                                                   PrimaryKey,
-                                                                                   indicator,
-                                                                                   percent)
+                                                                                                      indicator = paste0(current_prefix, indicator, "Cover")) |>
+                                                                       dplyr::mutate(indicator = stringr::str_replace_all(string = indicator,
+                                                                                                                          pattern = nonstandard_indicator_lookup)) # Fixed data = _ placeholder
 
-                                                                     if (!is.null(expected_indicator_names)) {
-                                                                       # Get only the indicators we want to actually keep. Doing this saves us
-                                                                       # from wasting memory storing unnecessary indicators even temporarily
-                                                                       # and spares us the horror of storing them even less efficiently in
-                                                                       # a wide format after this loop.
-                                                                       current_results <- dplyr::filter(.data = _,
-                                                                                                        indicator %in% expected_indicator_names)
-
-                                                                     }
-                                                                     current_results
+                                                                     dplyr::select(.data = current_results, PrimaryKey, indicator, percent)
                                                                    })
 
-                                    # Bind all those results together
                                     dplyr::bind_rows(current_results_list)
                                   })
 
-  # It's possible to accidentally calculate the same indicator more than once,
-  # e.g. in Alaska where you might find "Moss" in the variable GrowthHabitSub
-  # and so get a FH_MossCover when calculating both from GrowthHabitSub *AND*
-  # SpecialConsiderationCode
-  cover_indicators <- dplyr::bind_rows(cover_indicators_list) |>
-    dplyr::distinct()
+  cover_indicators <- dplyr::bind_rows(cover_indicators_list) |> dplyr::distinct()
 
   #### Combine all LPI based cover indicators ##################################
   if (verbose) {
     message("Combining all cover indicators and converting to a wide format.")
   }
-  # lpi_indicators <- dplyr::bind_rows(cover_indicators,
-  #                                    total_foliar) |>
-  #   # Remove duplicates (which I guess is possible)
-  #   dplyr::distinct(.data = _) |>
-  #   # Spread to a wide format.
-  #   tidyr::pivot_wider(data = _,
-  #                      names_from = indicator,
-  #                      values_from = percent,
-  #                      values_fill = 0)
+
   lpi_indicators <- tidyr::pivot_wider(data = cover_indicators,
                                        names_from = indicator,
                                        values_from = percent,
                                        values_fill = 0)
 
   ##### Sagebrush shape indicators ---------------------------------------------
-  # If there are qualifying data, add sagebrush shape!
   if ("ShrubShape" %in% names(lpi_species)) {
     if (any(!is.na(lpi_species$ShrubShape))) {
       if (verbose) {
         message("Calculating sagebrush shape indicators and joining to output.")
       }
-      # Sagebrush shape is only recorded for live sagebrush according to the
-      # protocol, so we're going to calculate with live = FALSE and rename it to
-      # reflect the living status
-      sagebrush_shape_calc <- sagebrush_shape(lpi_tall = lpi_species,
-                                              live = FALSE)
+
+      sagebrush_shape_calc <- sagebrush_shape(lpi_tall = lpi_species, live = FALSE)
 
       if (is.null(sagebrush_shape_calc)) {
-        if (verbose) {
-          message("sagebrush_shape() returned NULL. Skipping sagebrush shape indicators.")
-        }
+        if (verbose) { message("sagebrush_shape() returned NULL. Skipping sagebrush shape indicators.") }
       } else {
-        # Sagebrush shape is gathered regardless of live/dead status so we won't
-        # rename these indicators.
-        # sagebrush_shape_calc <- dplyr::rename_with(.data = sagebrush_shape_calc,
-        #                                            .fn = ~ stringr::str_replace(string = .x,
-        #                                                                         pattern = "_All_",
-        #                                                                         replacement = "_Live_"),
-        #                                            .cols = tidyselect::contains(match = "_All_"))
         lpi_indicators <- dplyr::left_join(x = lpi_indicators,
                                            y = sagebrush_shape_calc,
                                            relationship = "one-to-one",
                                            by = "PrimaryKey")
       }
-
     } else {
-      if (verbose) {
-        message("No qualifying data were found in ShrubShape. Skipping sagebrush shape indicators.")
-      }
+      if (verbose) { message("No qualifying data were found in ShrubShape. Skipping sagebrush shape indicators.") }
     }
   } else {
-    if (verbose) {
-      message("No variable called ShrubShape found. Skipping sagebrush shape indicators.")
-    }
-
+    if (verbose) { message("No variable called ShrubShape found. Skipping sagebrush shape indicators.") }
+  } # <-- FIXED: Added missing closing bracket here!
 
   #### Final munging ###########################################################
-  # Keep only the indicators we want
-  # output <- dplyr::select(.data = lpi_indicators,
-  #                         PrimaryKey,
-  #                         dplyr::any_of(expected_indicator_names))
-
-  # We need to make sure that all indicator variables are numeric because
-  # they're all cover values. Any NA values should be assumed to be 0s.
-  # output <- dplyr::mutate(.data = output,
   output <- dplyr::mutate(.data = lpi_indicators,
                           dplyr::across(.cols = -tidyselect::any_of(x = c("PrimaryKey",
                                                                           "SagebrushShape_All_Predominant")),
                                         .fns = ~ as.numeric(.x) |>
-                                          tidyr::replace_na(data = _,
-                                                            replace = 0) |>
-                                          round(x = _,
-                                                digits = digits)))
+                                          tidyr::replace_na(replace = 0) |>
+                                          round(digits = digits)))
 
-  # Add in variables for indicators we want but which had no qualifying data and
-  # therefore should have a value of 0 for all plots.
-  # setdiff() is rad and I wish I'd known about it years ago.
-  # We'll make sure to set ONLY the numeric indicators' NAs to 0.
-  # The character indicators get NAs.
   if (!is.null(expected_indicator_names)) {
-    # One day we'll handle this, but this is a stub for now.
     character_value_indicators <- NULL
     output_missing_numeric_indicators <- setdiff(x = expected_indicator_names,
-                                                 y = c(names(output),
-                                                       character_value_indicators))
+                                                 y = c(names(output), character_value_indicators))
     output[output_missing_numeric_indicators] <- 0
-    output_missing_character_indicators <- setdiff(x = character_value_indicators,
-                                                   y = names(output))
+    output_missing_character_indicators <- setdiff(x = character_value_indicators, y = names(output))
     output[output_missing_character_indicators] <- NA
 
     if (length(c(output_missing_numeric_indicators, output_missing_character_indicators)) > 0) {
-      warning(paste("The following indicators had no qualifying data and have been populated with 0 or NA as appropriate. This is not unexpected with rare situations and is even likely with smaller data sets. The indicators in question are:",
-                    paste(c(output_missing_numeric_indicators, output_missing_character_indicators),
-                          collapse = ", ")))
+      warning(paste("The following indicators had no qualifying data and have been populated with 0 or NA as appropriate. The indicators in question are:",
+                    paste(c(output_missing_numeric_indicators, output_missing_character_indicators), collapse = ", ")))
     }
 
-    # This will reorder the variables to be as expected!
     output <- dplyr::select(.data = output,
-                            dplyr::all_of(c("PrimaryKey",
-                                            expected_indicator_names)))
+                            dplyr::all_of(c("PrimaryKey", expected_indicator_names)))
   }
 
-    output
-
-  }
+  output
 }
-
-
 
 # Calculate the Gap indicators for AIM
 #' Calculate the standard Terrestrial AIM Database (TerrADat) Canopy Gap indicators

--- a/R/aim_gdb.R
+++ b/R/aim_gdb.R
@@ -1289,6 +1289,8 @@ height_calc <- function(header,
                                })
 
   output <- dplyr::bind_rows(height_values_list) |>
+    dplyr::mutate(.data = _,
+                  indicator = replace(indicator, indicator == "Hgt_Nonwoody_Avg", "Hgt_Herbaceous_Avg")) |>
     dplyr::filter(.data = _,
                   indicator %in% expected_indicator_variables) |>
     tidyr::pivot_wider(data = _,

--- a/R/aim_gdb.R
+++ b/R/aim_gdb.R
@@ -767,8 +767,7 @@ lpi_calc <- function(header,
                             by_line = FALSE,
                             indicator_variables = "Plant",
                             digits = digits) |>
-    dplyr::mutate(.data = _,
-                  indicator = "TotalFoliarCover")
+    dplyr::mutate(indicator = "TotalFoliarCover")
 
   ##### All other cover ########################################################
   # This is going to look gnarly, but automates stuff so we don't have to do the

--- a/R/aim_gdb.R
+++ b/R/aim_gdb.R
@@ -599,7 +599,9 @@ lpi_calc <- function(header,
   } else if (length(species_code_var) > 1) {
     stop("species_code_var must be a single character string specifying the name of the variable in the species_file that contains the species codes.")
   }
-
+  nonstandard_indicator_lookup <- c("FH_BareSoilCover" = "BareSoilCover",
+                                    "AH_SagebrushLiveCover" = "AH_SagebrushCover_Live",
+                                    "AH_BasalPlantCover" = "AH_BasalCover")
   #### Grouping variables lists ------------------------------------------------
   if (!is.null(indicators_vars)) {
     if (!is.list(indicators_vars)) {
@@ -637,9 +639,6 @@ lpi_calc <- function(header,
     variable_groups <- default_indicators_vars(source = "terradat", verbose = verbose)
   }
 
-  nonstandard_indicator_lookup <- c("FH_BareSoilCover" = "BareSoilCover",
-                                    "AH_SagebrushLiveCover" = "AH_SagebrushCover_Live",
-                                    "AH_BasalPlantCover" = "AH_BasalCover")
 
   #### Handling header and raw data ############################################
   header <- read_with_fallback(dsn = header,
@@ -841,6 +840,8 @@ lpi_calc <- function(header,
                                                                                                         indicator %in% expected_indicator_names)
 
                                                                      }
+                                                                     current_results
+                                                                   })
 
                                     dplyr::bind_rows(current_results_list)
                                   })

--- a/R/aim_gdb.R
+++ b/R/aim_gdb.R
@@ -672,7 +672,7 @@ lpi_calc <- function(header,
                                       y = lpi_tall,
                                       relationship = "one-to-many",
                                       by = "PrimaryKey")
-                       
+
     if (verbose) {
       message("Checking species_file and reading in as necessary.")
     }
@@ -1042,7 +1042,7 @@ lpi_calc <- function(header,
     output
 
   }
-
+}
 
 
 
@@ -1854,3 +1854,4 @@ soil_stability_calc <- function(soil_stability_tall,
                                digits = digits)
   indicators
 }
+

--- a/R/aim_gdb.R
+++ b/R/aim_gdb.R
@@ -637,6 +637,10 @@ lpi_calc <- function(header,
     variable_groups <- default_indicators_vars(source = "terradat", verbose = verbose)
   }
 
+  nonstandard_indicator_lookup <- c("FH_BareSoilCover" = "BareSoilCover",
+                                    "AH_SagebrushLiveCover" = "AH_SagebrushCover_Live",
+                                    "AH_BasalPlantCover" = "AH_BasalCover")
+
   #### Handling header and raw data ############################################
   header <- read_with_fallback(dsn = header,
                                tbl = NULL,
@@ -814,12 +818,29 @@ lpi_calc <- function(header,
                                                                                               "any" = "AH_",
                                                                                               "basal" = "AH_Basal")
                                                                      current_results <- dplyr::mutate(.data = current_results,
-                                                                                                      indicator = paste0(current_prefix, indicator, "Cover")) |>
-                                                                       dplyr::mutate(indicator = stringr::str_replace_all(string = indicator,
-                                                                                                                          pattern = nonstandard_indicator_lookup)) # Fixed data = _ placeholder
+                                                                                                      indicator = paste0(current_prefix,
+                                                                                                                         indicator,
+                                                                                                                         "Cover")) |>
+                                                                       # And correct for the special case indicators
+                                                                       dplyr::mutate(.data = _,
+                                                                                     indicator = dplyr::replace_values(x = indicator,
+                                                                                                                       from = names(nonstandard_indicator_lookup),
+                                                                                                                       to = nonstandard_indicator_lookup)) |>
+                                                                       # We'll keep only the bare minimum here.
+                                                                       dplyr::select(.data = _,
+                                                                                     PrimaryKey,
+                                                                                     indicator,
+                                                                                     percent)
 
-                                                                     dplyr::select(.data = current_results, PrimaryKey, indicator, percent)
-                                                                   })
+                                                                     if (!is.null(expected_indicator_names)) {
+                                                                       # Get only the indicators we want to actually keep. Doing this saves us
+                                                                       # from wasting memory storing unnecessary indicators even temporarily
+                                                                       # and spares us the horror of storing them even less efficiently in
+                                                                       # a wide format after this loop.
+                                                                       current_results <- dplyr::filter(.data = current_results,
+                                                                                                        indicator %in% expected_indicator_names)
+
+                                                                     }
 
                                     dplyr::bind_rows(current_results_list)
                                   })

--- a/R/aim_gdb.R
+++ b/R/aim_gdb.R
@@ -857,7 +857,14 @@ lpi_calc <- function(header,
                                        names_from = indicator,
                                        values_from = percent,
                                        values_fill = 0)
-
+  #### Add in total foliar!
+  total_foliar <- total_foliar %>%
+    rename(TotalFoliarCover = percent) %>%
+    select(-indicator)
+  lpi_indicators <- dplyr::left_join(x = lpi_indicators,
+                                     y = total_foliar,
+                                     relationship = "one-to-one",
+                                     by = "PrimaryKey")
   ##### Sagebrush shape indicators ---------------------------------------------
   if ("ShrubShape" %in% names(lpi_species)) {
     if (any(!is.na(lpi_species$ShrubShape))) {

--- a/R/gathering.R
+++ b/R/gathering.R
@@ -4535,13 +4535,9 @@ gather_species_inventory_lmf <- function(dsn = NULL,
                       relationship = "one-to-many")
 
   # rename fields
-  species_inventory <- dplyr::rename(.data = species_inventory,
-                                     Species = CPLANT)
-
-
-  dplyr::select(.data = species_inventory,
-                -c(SURVEY:SEQNUM),
-                -tidyselect::any_of(internal_gdb_vars))
+  species_inventory <- species_inventory |>
+    dplyr::rename(Species = CPLANT) |>
+    dplyr::select(-c(SURVEY:SEQNUM), -tidyselect::any_of(internal_gdb_vars))
 
   species_inventory
 }

--- a/R/pct_cover.R
+++ b/R/pct_cover.R
@@ -380,7 +380,7 @@ pct_bareground <- function(lpi_tall,
     # output.
     dplyr::mutate(.data = _,
                   BareSoil = dplyr::case_when(BareSoil %in% soil_values ~ "BareSoil",
-                                              .defatul = NA)) |>
+                                              .default = NA)) |>
     # Calculate!
     pct_cover(lpi_tall = _,
               tall = tall,

--- a/R/species.R
+++ b/R/species.R
@@ -633,12 +633,30 @@ species_join <- function(data, # field data,
                                 tidyselect::all_of(x = setNames(object = species_code,
                                                                 nm = data_code)),
                                 tidyselect::everything()) |>
+    # in certain instances NA and NULL strings are persisting in the species list
+    dplyr::filter(!is.na(!!rlang::sym(data_code)) & !!rlang::sym(data_code) != "") |>
+
+    # critical! join by to prevent weird default behavior in species assignments
     dplyr::left_join(x = data,
                      y = _,
-                     # Enforcing that there shouldn't be multiple records in
-                     # species_generic that share a code!!!!!
                      relationship = "many-to-one",
-                     by = join_by) |>
+                     by = dplyr::join_by(!!data_code)) |>
+
+    # fallback logic where if nothing is assigned in species we at least know whether woody or herb
+    dplyr::mutate(
+      # Since we cleaned the lookup table, if Duration is NA, the species was unmatched
+      is_unmatched = is.na(Duration),
+
+      # Enforce NA for unmatched sub-metrics
+      Duration       = dplyr::if_else(is_unmatched, NA_character_, Duration),
+      GrowthHabitSub = dplyr::if_else(is_unmatched, NA_character_, GrowthHabitSub),
+
+      # Fall back to your measured column values if unmatched, otherwise keep lookup value
+      GrowthHabit    = dplyr::if_else(is_unmatched, GrowthHabit_measured, GrowthHabit)
+    ) |>
+
+    # Clean up the helper column and drop duplicates
+    dplyr::select(-is_unmatched) |>
     dplyr::distinct()
 
   # Overwrite generic species assignments with provided table

--- a/R/species.R
+++ b/R/species.R
@@ -180,9 +180,10 @@ generic_growth_habits <- function(data,
                                "NonWoody" = "^2((F(?!SMUT|[FJRU]))|(G(?!W)|(VH)))",
                                "Nonvascular" = "^2(A|BRY|HORN|L(?!TR)|LTRL|MOSS|PROT|SLIME)",
                                "Other" = "^2(PLANT|BACT|CYAN|DIAT|DINO|(F(?=SMUT|[FJRU])|(LTR(?!L))))")
-  aim_growthhabit_regexes <- c("Woody" = "^((S[HU]|TR)\\d{1,999})|(SSHH|TTRR|SSUU)",
-                               "NonWoody" = "^(([AP]{1,2}[FG]{1,2})|(PPSS))\\d{1,999}$",
+  aim_growthhabit_regexes <- c("Woody" = "^([AP]{1,2})?((S[HU]|TR)\\d{0,999})$|^(SSHH|TTRR|SSUU)$",
+                               "NonWoody" = "^(([AP]{1,2}[FG]{1,2})|(PPSS))\\d{0,999}$",
                                "Nonvascular" = "^(VL|CY|LC|M)$")
+
 
   # Growth habit sub regexes
   lmf_growthhabitsub_regexes <- c("Forb" = "^2F(?![FJRSU])",
@@ -191,11 +192,11 @@ generic_growth_habits <- function(data,
                                   "Shrub" = "^2((S[BDEHN])|(S$))",
                                   "Graminoid" = "^2G",
                                   "Succulent" = "^2(FS(?!(MUT)|(UNGI))|(SS(?![BDEN]))|(TS))")
-  aim_growthhabitsub_regexes <- c("Forb" = "^[AP]{1,2}F{1,2}\\d{1,999}$",
-                                  "Tree" = "^TR\\d{1,999}$",
-                                  "Shrub" = "^((SH)|(SSHH))\\d{1,999}$",
-                                  "Graminoid" = "^[AP]{1,2}G{1,2}\\d{1,999}$",
-                                  "Succulent" = "^SU\\d{1,999}$")
+  aim_growthhabitsub_regexes <- c("Forb" = "^[AP]{1,2}F{1,2}\\d{0,999}$",
+                                  "Tree" = "^([AP]{1,2})?TR\\d{0,999}$",
+                                  "Shrub" = "^([AP]{1,2})?((SH)|(SSHH))\\d{0,999}$",
+                                  "Graminoid" = "^[AP]{1,2}G{1,2}\\d{0,999}$",
+                                  "Succulent" = "^([AP]{1,2})?SU\\d{0,999}$")
 
   # Duration regexes
   lmf_duration_regexes <- c("Annual" = "^2(([FG]|VH)[DMSL]?[AB])$",

--- a/R/species.R
+++ b/R/species.R
@@ -180,8 +180,8 @@ generic_growth_habits <- function(data,
                                "NonWoody" = "^2((F(?!SMUT|[FJRU]))|(G(?!W)|(VH)))",
                                "Nonvascular" = "^2(A|BRY|HORN|L(?!TR)|LTRL|MOSS|PROT|SLIME)",
                                "Other" = "^2(PLANT|BACT|CYAN|DIAT|DINO|(F(?=SMUT|[FJRU])|(LTR(?!L))))")
-  aim_growthhabit_regexes <- c("Woody" = "^([AP]{1,2})?((S[HU]|TR)\\d{0,999})$|^(SSHH|TTRR|SSUU)$",
-                               "NonWoody" = "^(([AP]{1,2}[FG]{1,2})|(PPSS))\\d{0,999}$",
+  aim_growthhabit_regexes <- c("Woody" = "^(((A{1,2}|P{1,2})?(S[HU]|TR))|SSHH|TTRR|SSUU)\\d*$",
+                               "NonWoody" = "^(((A{1,2}|P{1,2})[FG]{1,2})|PPSS)\\d*$",
                                "Nonvascular" = "^(VL|CY|LC|M)$")
 
 
@@ -192,17 +192,17 @@ generic_growth_habits <- function(data,
                                   "Shrub" = "^2((S[BDEHN])|(S$))",
                                   "Graminoid" = "^2G",
                                   "Succulent" = "^2(FS(?!(MUT)|(UNGI))|(SS(?![BDEN]))|(TS))")
-  aim_growthhabitsub_regexes <- c("Forb" = "^[AP]{1,2}F{1,2}\\d{0,999}$",
-                                  "Tree" = "^([AP]{1,2})?TR\\d{0,999}$",
-                                  "Shrub" = "^([AP]{1,2})?((SH)|(SSHH))\\d{0,999}$",
-                                  "Graminoid" = "^[AP]{1,2}G{1,2}\\d{0,999}$",
-                                  "Succulent" = "^([AP]{1,2})?SU\\d{0,999}$")
+   aim_growthhabitsub_regexes <- c("Forb" = "^(A{1,2}|P{1,2})F{1,2}\\d*$",
+                                  "Tree" = "^(P{1,2})?TR\\d*$",
+                                  "Shrub" = "^(((P{1,2})?SH)|(SSHH))\\d*$",
+                                  "Graminoid" = "^(A{1,2}|P{1,2})G{1,2}\\d*$",
+                                  "Succulent" = "^(A{1,2}|P{1,2})?SU\\d*$")
 
   # Duration regexes
   lmf_duration_regexes <- c("Annual" = "^2(([FG]|VH)[DMSL]?[AB])$",
                             "Perennial" = "^2((F[DMS]?P)|(GL?[PN])|(GRAM)|(S(?!LIME).*)|(T.*)|(VH[DMS]?P)|(VW.*))$")
-  aim_duration_regexes <- c("Annual" = "^A{1,2}[FG]{1,2}\\d{1,999}",
-                            "Perennial" = "^(((P{1,2}[FG]{1,2})|(TR)|(PPSS))\\d{1,999})|(S{1,2}[HU]{1,2})")
+  aim_duration_regexes <- c("Annual" = "^A{1,2}([FG]{1,2}|SU|SS)\\d*$",
+                            "Perennial" = "^(((P{1,2}(F{1,2}G{1,2}))|((P{1,2})?TR)|(PPSS))\\d*)$|^((((P{1,2})?SH)|(SSHH))|((P{1,2})?SU))\\d*$")
 
   regexes_list <- list("GrowthHabit" = c(lmf_growthhabit_regexes,
                                          aim_growthhabit_regexes),

--- a/R/species.R
+++ b/R/species.R
@@ -238,7 +238,11 @@ generic_growth_habits <- function(data,
             collapse = ", ")
     stop(paste0("The following expected variables are missing from species_list: ", bad_variables_string))
   }
-
+  #### Define Codes to Ignore #####################################
+  codes_to_ignore <- c(
+    "DS", "D", "LC", "2LICHN", "2LICHN1", "VL", "M", "2MOSS", "2MOSS1",
+    "CY", "W", "WA", "AG", "CM", "LM", "FG", "PC", "S"
+  )
   # Which codes in the data aren't represented in the species_list provided?
   # These are the codes that we'll attempt to interpret as generics.
   missing_codes_df <- dplyr::select(.data = data,
@@ -246,6 +250,7 @@ generic_growth_habits <- function(data,
     dplyr::distinct(.data = _) |>
     dplyr::filter(.data = _,
                   !(code %in% species_list[[species_code]]),
+                  !(code %in% codes_to_ignore),
                   !is.na(code)) |>
     dplyr::select(.data = _,
                   tidyselect::all_of(x = setNames(object = "code",
@@ -648,7 +653,7 @@ species_join <- function(data, # field data,
                      y = _,
                      relationship = "many-to-one",
                      by = dplyr::join_by(!!data_code)) |>
-    
+
     # Safely assign GrowthHabit when missing ONLY if measurement columns are present
     dplyr::mutate(
       GrowthHabit = if ("Height" %in% names(data) && "GrowthHabit_measured" %in% names(data)) {

--- a/R/species.R
+++ b/R/species.R
@@ -643,20 +643,22 @@ species_join <- function(data, # field data,
                                 tidyselect::everything()) |>
     # remove blank and NAs from species list
     dplyr::filter(!is.na(!!rlang::sym(data_code)) & !!rlang::sym(data_code) != "") |>
-
-    # The join handles the lookup for the entire dataset efficiently
+# Enforce left_join behavior mapping many-to-one
     dplyr::left_join(x = data,
                      y = _,
                      relationship = "many-to-one",
                      by = dplyr::join_by(!!data_code)) |>
-
-    # assign GrowthHabit when missing
+    
+    # Safely assign GrowthHabit when missing ONLY if measurement columns are present
     dplyr::mutate(
-      # default to GrowthHabit_measured when not an intentional NA
-      GrowthHabit    = dplyr::case_when(
-        !(!!rlang::sym(data_code) %in% acceptable_nas) & is.na(GrowthHabit) & Height > 0 ~ GrowthHabit_measured,
-        .default = GrowthHabit
-      )
+      GrowthHabit = if ("Height" %in% names(data) && "GrowthHabit_measured" %in% names(data)) {
+        dplyr::case_when(
+          !(!!rlang::sym(data_code) %in% acceptable_nas) & is.na(GrowthHabit) & Height > 0 ~ GrowthHabit_measured,
+          .default = GrowthHabit
+        )
+      } else {
+        GrowthHabit
+      }
     ) |>
     dplyr::distinct()
 

--- a/R/species.R
+++ b/R/species.R
@@ -629,35 +629,36 @@ species_join <- function(data, # field data,
 
   # Make sure that the variables containing the codes are named the same thing
   # between the species list and the data then join them!
+  # intentional NAs to keep GrowthHabit assignment in species join
+  acceptable_nas <- species_generic |>
+    dplyr::filter(is.na(GrowthHabit)) |>
+    dplyr::pull(!!rlang::sym(species_code)) |>
+    unique()
+
+
   data_species <- dplyr::select(.data = species_generic,
                                 tidyselect::all_of(x = setNames(object = species_code,
                                                                 nm = data_code)),
                                 tidyselect::everything()) |>
-    # in certain instances NA and NULL strings are persisting in the species list
+    # remove blank and NAs from species list
     dplyr::filter(!is.na(!!rlang::sym(data_code)) & !!rlang::sym(data_code) != "") |>
 
-    # critical! join by to prevent weird default behavior in species assignments
+    # The join handles the lookup for the entire dataset efficiently
     dplyr::left_join(x = data,
                      y = _,
                      relationship = "many-to-one",
                      by = dplyr::join_by(!!data_code)) |>
 
-    # fallback logic where if nothing is assigned in species we at least know whether woody or herb
+    # assign GrowthHabit when missing
     dplyr::mutate(
-      # Since we cleaned the lookup table, if Duration is NA, the species was unmatched
-      is_unmatched = is.na(Duration),
-
-      # Enforce NA for unmatched sub-metrics
-      Duration       = dplyr::if_else(is_unmatched, NA_character_, Duration),
-      GrowthHabitSub = dplyr::if_else(is_unmatched, NA_character_, GrowthHabitSub),
-
-      # Fall back to your measured column values if unmatched, otherwise keep lookup value
-      GrowthHabit    = dplyr::if_else(is_unmatched, GrowthHabit_measured, GrowthHabit)
+      # default to GrowthHabit_measured when not an intentional NA
+      GrowthHabit    = dplyr::case_when(
+        !(!!rlang::sym(data_code) %in% acceptable_nas) & is.na(GrowthHabit) & Height > 0 ~ GrowthHabit_measured,
+        .default = GrowthHabit
+      )
     ) |>
-
-    # Clean up the helper column and drop duplicates
-    dplyr::select(-is_unmatched) |>
     dplyr::distinct()
+
 
   # Overwrite generic species assignments with provided table
   if (overwrite_generic_species & identical(generic_species_file, "")) {

--- a/R/support.R
+++ b/R/support.R
@@ -306,7 +306,7 @@ lpi_indicator_definitions <- function(){
                            "EmbLitter" = c("EL"))
 
   rock_codes_init = c("R", "GR", "CB", "ST", "BY", "RF", "BR")
-  
+
   list(
     #### Litter code categories ------------------------------------------------
     litter_codes = litter_codes_init,
@@ -561,7 +561,7 @@ adjust_species_attributes <- function(data,
                           #                                               NA)) & nchar(code) >= 3 ~ "Plant",
                           #                          .default = NA)
                           Plant = dplyr::case_when(!(GrowthHabitSub %in% c("growthhabitsub_irrelevant")) &
-                                                     GrowthHabit != "Nonvascular",
+                                                     GrowthHabit != "Nonvascular"&
                                                    stringi::stri_length(code) >= 3 ~ "Plant",
                                                    .default = NA)
     )


### PR DESCRIPTION
This branch was passing my tests for ingests. Native piping x = _  or .data=_ was causing an error in aim_gdb. lpi_indicators <- tidyr::pivot_wider(data = cover_indicators,
-                                       names_from = indicator,
-                                       values_from = percent,
-                                       values_fill = 0)
-  #### Add in total foliar!
-  total_foliar <- total_foliar %>%
-    rename(TotalFoliarCover = percent) %>%
-    select(-indicator)
-  lpi_indicators <- dplyr::left_join(x = lpi_indicators,
-                                     y = total_foliar,
-                                     relationship = "one-to-one",
-                                     by = "PrimaryKey")
is critical for actually capturing total foliar

-    dplyr::mutate(.data = _,
-                  indicator = replace(indicator, indicator == "Hgt_Nonwoody_Avg", "Hgt_Herbaceous_Avg")) |>
critical to keep heght herb