### PR TITLE
 Soil stability error prevention

### DIFF
--- a/R/gathering.R
+++ b/R/gathering.R
@@ -3560,7 +3560,8 @@ gather_soil_stability_terradat <- function(dsn = NULL,
                          "DataErrorChecking",
                          "DataEntry",
                          "DateModified",
-                         "FormType")
+                         "FormType",
+                         "X")
   #### Reading #################################################################
   header <- read_with_fallback(dsn = dsn,
                                tbl = tblSoilStabHeader,
@@ -3667,7 +3668,8 @@ gather_soil_stability_terradat <- function(dsn = NULL,
   # grabs only the records with identical "variable" values. It then renames the
   # "value" variable to use whatever the "variable" value is for that set of
   # data and drops the "variable" variable.
-  detail_tidy <- lapply(X = unique(detail_tall$variable),
+  detail_tidy <- lapply(X = setdiff(x = unique(detail_tall$variable),
+                                    y = c(NA)),
                         detail_tall = detail_tall,
                         FUN = function(X, detail_tall){
                           # Renaming the "value" variable and then

--- a/R/gathering.R
+++ b/R/gathering.R
@@ -3701,21 +3701,26 @@ gather_soil_stability_terradat <- function(dsn = NULL,
     # And the last bit is coercing things to numeric.
     dplyr::mutate(.data = _,
                   dplyr::across(.cols = tidyselect::all_of(c("Position",
-                                                              "Rating",
-                                                             "Hydro")),
-                                # # Can't trust the variables to be coercible to
-                                # # numeric without introducing NAs. Even though
-                                # # that'd be possible in a pristine data set,
-                                # # you'll probably never have one. So, we check
-                                # # to see if coercion does violence and only
-                                # # coerce variables we won't damage.
-                                # .fns = ~ if(any(suppressWarnings(is.na(as.numeric(.x))))) {
-                                #   .x
-                                # } else {
-                                #   as.numeric(.x)
-                                # })
-                                .fns = as.numeric)
-                  )
+                                                             "Rating")),
+                                # These should be numeric every time, so we'll
+                                # coerce them.
+                                .fns = as.numeric),
+                  dplyr::across(.cols = tidyselect::all_of(c("Hydro")),
+                                # Hydro is supposed to end up numeric, but the
+                                # incoming data is sometimes "0" and "1" but
+                                # might also be "TRUE" and "FALSE". This will
+                                # attempt to coerce it as though it's both and
+                                # keep only the one that worked or NA if neither
+                                # did.
+                                .fns = ~ dplyr::coalesce(as.logical(.x) |>
+                                                           as.numeric(),
+                                                         as.numeric(.x)) |>
+                                  # This approach is almost certainly going to
+                                  # trigger a warning about introducing NAs in
+                                  # the coercion, but that's okay because we
+                                  # expect that so we're going to suppress that.
+                                  suppressWarnings())
+    )
 
   # Find illegal values where the rating is not 6 but they're still marked as
   # hydrophobic


### PR DESCRIPTION
This stops the function from trying to tidy variables that didn't have a numeric suffix (e.g., BoxNum) and adds special handling for Hydro to accommodate situations where the values are "TRUE"/"FALSE" instead of "1"/"0".